### PR TITLE
isdigit function is deprecated

### DIFF
--- a/src/getMutationTypes.pl
+++ b/src/getMutationTypes.pl
@@ -130,7 +130,7 @@ while ($line = <VCFFILE>)
     	{
     		$checkChr++;
     	}
-    	elsif (isdigit($chr))
+    	elsif ($chr =~ /^\d+?$/)
     	{
     		if (($chr > 0) and ($chr < 23))
     		{


### PR DESCRIPTION
The isdigit function in POSIX was removed as of v5.24. I've replaced with a simple check that should work instead. I haven't removed POSIX from getting loaded (line 8) because I'm not sure whether it's needed elsewhere.