### PR TITLE
fix simulation bug

### DIFF
--- a/src/generate_simulations.py
+++ b/src/generate_simulations.py
@@ -79,7 +79,7 @@ class RandomData(object):
 		"""
 		time_points = []
 
-		selected_signatures = signature_matrix[1:, np.where(np.intersect1d(signature_matrix[0, :], self._signatures))]
+		selected_signatures = signature_matrix[1:, np.where(np.isin(signature_matrix[0, :], self._signatures))[0]]
 
 		selected_signatures = selected_signatures.reshape(selected_signatures.shape[0], len(self._signatures)).astype(float)
 		for i in exposure.T:


### PR DESCRIPTION
This is a proposed fix for a bug found in the Generating Simulations module of the code. This bug causes the current program to always use signatures S1, S2, S3, S4 from the alexSignatures table instead of the selected 4 signatures (S1, S5 + two randomly chosen) to calculate the loading probabilities for each simulated sample. As a result, the TrackSig-inferred signature activities for simulated data will look very different from the simulated ground truth.